### PR TITLE
NIST SP 800-63Bに一部沿ってパスワードルールの変更

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -172,7 +172,7 @@ function ChangeAccountSection() {
             <TextFieldRHF
               required
               name="currentPassword"
-              pattern="^[\x20-\x7E]+$"
+              pattern="^[\x21-\x7E]+$"
               autoComplete="current-password"
               control={control}
               type="password"
@@ -243,7 +243,7 @@ function ChangeAccountSection() {
             <ExpandableFields show={changePassword}>
               <TextFieldRHF
                 name="newPassword"
-                pattern="^[\x20-\x7E]+$"
+                pattern="^[\x21-\x7E]+$"
                 autoComplete="new-password"
                 control={control}
                 type="password"
@@ -253,7 +253,7 @@ function ChangeAccountSection() {
               />
               <TextFieldRHF
                 name="newPasswordConfirm"
-                pattern="^[\x20-\x7E]+$"
+                pattern="^[\x21-\x7E]+$"
                 autoComplete="new-password"
                 control={control}
                 type="password"
@@ -347,7 +347,7 @@ function DeleteAccountSection() {
             <TextFieldRHF
               required
               name="currentPassword"
-              pattern="^[\x20-\x7E]+$"
+              pattern="^[\x21-\x7E]+$"
               autoComplete="current-password"
               control={control}
               type="password"

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -172,7 +172,7 @@ function ChangeAccountSection() {
             <TextFieldRHF
               required
               name="currentPassword"
-              pattern="^[\x00-\x7F]+$"
+              pattern="^[\x20-\x7E]+$"
               autoComplete="current-password"
               control={control}
               type="password"
@@ -243,7 +243,7 @@ function ChangeAccountSection() {
             <ExpandableFields show={changePassword}>
               <TextFieldRHF
                 name="newPassword"
-                pattern="^[\x00-\x7F]+$"
+                pattern="^[\x20-\x7E]+$"
                 autoComplete="new-password"
                 control={control}
                 type="password"
@@ -253,7 +253,7 @@ function ChangeAccountSection() {
               />
               <TextFieldRHF
                 name="newPasswordConfirm"
-                pattern="^[\x00-\x7F]+$"
+                pattern="^[\x20-\x7E]+$"
                 autoComplete="new-password"
                 control={control}
                 type="password"
@@ -347,7 +347,7 @@ function DeleteAccountSection() {
             <TextFieldRHF
               required
               name="currentPassword"
-              pattern="^[\x00-\x7F]+$"
+              pattern="^[\x20-\x7E]+$"
               autoComplete="current-password"
               control={control}
               type="password"

--- a/src/global/component/SignIn.tsx
+++ b/src/global/component/SignIn.tsx
@@ -166,7 +166,7 @@ function SignInForm({ open, openToggle }: { open: boolean; openToggle: (value: b
           <TextFieldRHF
             required
             name="password"
-            pattern="^[\x20-\x7E]+$"
+            pattern="^[\x21-\x7E]+$"
             autoComplete="off"
             control={control}
             type="password"

--- a/src/global/component/SignIn.tsx
+++ b/src/global/component/SignIn.tsx
@@ -166,7 +166,7 @@ function SignInForm({ open, openToggle }: { open: boolean; openToggle: (value: b
           <TextFieldRHF
             required
             name="password"
-            pattern="^[\x00-\x7F]+$"
+            pattern="^[\x20-\x7E]+$"
             autoComplete="off"
             control={control}
             type="password"

--- a/src/global/component/SignUp.tsx
+++ b/src/global/component/SignUp.tsx
@@ -176,7 +176,7 @@ function SignUpForm() {
           <TextFieldRHF
             required
             name="password"
-            pattern="^[\x00-\x7F]+$"
+            pattern="^[\x20-\x7E]+$"
             autoComplete="off"
             control={control}
             type="password"
@@ -189,7 +189,7 @@ function SignUpForm() {
           <TextFieldRHF
             required
             name="passwordConfirm"
-            pattern="^[\x00-\x7F]+$"
+            pattern="^[\x20-\x7E]+$"
             autoComplete="off"
             control={control}
             type="password"

--- a/src/global/component/SignUp.tsx
+++ b/src/global/component/SignUp.tsx
@@ -176,7 +176,7 @@ function SignUpForm() {
           <TextFieldRHF
             required
             name="password"
-            pattern="^[\x20-\x7E]+$"
+            pattern="^[\x21-\x7E]+$"
             autoComplete="off"
             control={control}
             type="password"
@@ -189,7 +189,7 @@ function SignUpForm() {
           <TextFieldRHF
             required
             name="passwordConfirm"
-            pattern="^[\x20-\x7E]+$"
+            pattern="^[\x21-\x7E]+$"
             autoComplete="off"
             control={control}
             type="password"

--- a/src/global/valid/passwordDenylist.ts
+++ b/src/global/valid/passwordDenylist.ts
@@ -48,6 +48,12 @@ const leetToAlphaMap: Record<string, string> = {
   '!': 'i',
 };
 
+const hasConsecutiveSameCharRun = (value: string, minRunLength = 15): boolean => {
+  const escapedLength = Math.max(1, minRunLength - 1);
+  const pattern = new RegExp(`(.)\\1{${escapedLength},}`);
+  return pattern.test(value);
+};
+
 const normalizePasswordForBlocklist = (password: string): string => {
   const lower = password.toLowerCase();
   return Array.from(lower)
@@ -57,6 +63,10 @@ const normalizePasswordForBlocklist = (password: string): string => {
 };
 
 export const isCommonPassword = (password: string): boolean => {
+  if (hasConsecutiveSameCharRun(password, 15)) {
+    return true;
+  }
+
   const normalized = normalizePasswordForBlocklist(password);
 
   if (commonPasswordBlocklist.has(normalized)) {

--- a/src/global/valid/passwordDenylist.ts
+++ b/src/global/valid/passwordDenylist.ts
@@ -15,7 +15,7 @@ const commonPasswordBlocklist = new Set([
   'welcome123456789',
   'iloveyou1234567',
   'abc123abc123abc',
-  'p@ssw0rd1234567',
+  'password1234567',
 ]);
 
 const commonPasswordRoots = [

--- a/src/global/valid/passwordDenylist.ts
+++ b/src/global/valid/passwordDenylist.ts
@@ -1,0 +1,70 @@
+/**
+ * @module passwordDenylist
+ * @description よく使用される推測されやすいパスワードを判定するユーティリティ。
+ */
+
+const commonPasswordBlocklist = new Set([
+  '123456789012345',
+  '111111111111111',
+  '000000000000000',
+  'qwerty1234567890',
+  'qwertyuiop12345',
+  'admin1234567890',
+  'adminadmin12345',
+  'letmein123456789',
+  'welcome123456789',
+  'iloveyou1234567',
+  'abc123abc123abc',
+  'p@ssw0rd1234567',
+]);
+
+const commonPasswordRoots = [
+  'password',
+  'qwerty',
+  'admin',
+  'letmein',
+  'welcome',
+  'iloveyou',
+  'abc123',
+  'dragon',
+  'monkey',
+  'princess',
+  'football',
+  'baseball',
+  'login',
+  'master',
+  'superman',
+  'sunshine',
+  'freedom',
+  'whatever',
+  'secret',
+  'charlie',
+];
+
+const leetToAlphaMap: Record<string, string> = {
+  '@': 'a',
+  $: 's',
+  '0': 'o',
+  '!': 'i',
+};
+
+const normalizePasswordForBlocklist = (password: string): string => {
+  const lower = password.toLowerCase();
+  return Array.from(lower)
+    .map((char) => leetToAlphaMap[char] ?? char)
+    .join('')
+    .replace(/[^a-z0-9]/g, '');
+};
+
+export const isCommonPassword = (password: string): boolean => {
+  const normalized = normalizePasswordForBlocklist(password);
+
+  if (commonPasswordBlocklist.has(normalized)) {
+    return true;
+  }
+
+  return commonPasswordRoots.some((root) => {
+    const rootPattern = new RegExp(`^${root}(\\d+)?$`);
+    return rootPattern.test(normalized);
+  });
+};

--- a/src/global/valid/userInfo.ts
+++ b/src/global/valid/userInfo.ts
@@ -5,12 +5,15 @@
 import * as z from 'zod';
 import { fetcher } from '../function/fetch/fetch';
 import { reactDebounce } from '../function/reactDebounce';
+import { isCommonPassword } from './passwordDenylist';
 
 export const baseUserInfoSchema = z.object({
   id: z.coerce
     .string()
     .trim()
-    .min(4, { error: '4文字上のIDを入力してください' })
+    .min(4, {
+      error: '4文字上のIDを入力してください',
+    })
     .regex(/^[a-zA-Z0-9]+$/, {
       error: '英大文字、英小文字、数字で入力してください',
     })
@@ -20,43 +23,44 @@ export const baseUserInfoSchema = z.object({
   password: z
     .string()
     .trim()
-    .min(8, {
-      error: '8文字以上のパスワードを英大文字、英小文字、数字を含めて入力してください',
+    .min(15, {
+      error: '15文字以上のパスワードを入力してください',
     })
-    .max(24, {
-      error: '24文字以下のパスワードを英大文字、英小文字、数字を含めて入力してください',
-    })
-    .regex(/(?=.*?[a-zA-Z])(?=.*?\d)[!-~]+/, {
-      error: '英大文字、英小文字、数字を含めて入力してください',
-    })
-    .regex(/^(?=.*[A-Za-z])(?=.*\d)[\x20-\x7E]+$/, {
-      error: '全角文字は使用できません',
+    .regex(/^[\x20-\x7E]+$/, {
+      error: '半角文字のみで入力してください',
     })
     .regex(/^[^<>&"'/`={}():%]+$/, {
       error: '「^ < > & " \' ` = { } ( ) : %」は使用できません',
+    })
+    .refine((value) => !isCommonPassword(value), {
+      error: 'よく使用される推測されやすいパスワードは使用できません',
     }),
   passwordConfirm: z.string().min(1, { error: 'もう一度パスワードを入力してください' }),
   userName: z.coerce
     .string()
     .trim()
     .min(1, { error: 'お名前を入力してください' })
-    .max(16, { error: '16文字以内で入力してください' })
     .regex(/^[^<>&"'/`={}():%]+$/, {
       error: '「^ < > & " \' ` = { } ( ) : %」は使用できません',
     })
     .regex(/^[^\p{Emoji_Presentation}\p{Extended_Pictographic}]+$/u, {
       error: '絵文字は使用できません',
+    })
+    .max(16, {
+      error: '16文字以内で入力してください',
     }),
   islandName: z.coerce
     .string()
     .trim()
     .min(1, { error: '島名を入力してください' })
-    .max(16, { error: '16文字以内の島名を入力してください' })
     .regex(/[^島]$/, {
       error: '末尾に「島」は使用できません',
     })
     .regex(/^[^<>&"'/`={}():%]+$/, {
       error: '「^ < > & " \' ` = { } ( ) : %」は使用できません',
+    })
+    .max(16, {
+      error: '16文字以内の島名を入力してください',
     }),
 });
 

--- a/src/global/valid/userInfo.ts
+++ b/src/global/valid/userInfo.ts
@@ -26,7 +26,7 @@ export const baseUserInfoSchema = z.object({
     .min(15, {
       error: '15文字以上のパスワードを入力してください',
     })
-    .regex(/^[\x20-\x7E]+$/, {
+    .regex(/^[\x21-\x7E]+$/, {
       error: '半角文字のみで入力してください',
     })
     .regex(/^[^<>&"'/`={}():%]+$/, {
@@ -35,10 +35,7 @@ export const baseUserInfoSchema = z.object({
     .refine((value) => !isCommonPassword(value), {
       error: 'よく使用される推測されやすいパスワードは使用できません',
     }),
-  passwordConfirm: z
-    .string()
-    .trim()
-    .min(1, { error: 'もう一度パスワードを入力してください' }),
+  passwordConfirm: z.string().trim().min(1, { error: 'もう一度パスワードを入力してください' }),
   userName: z.coerce
     .string()
     .trim()

--- a/src/global/valid/userInfo.ts
+++ b/src/global/valid/userInfo.ts
@@ -35,7 +35,10 @@ export const baseUserInfoSchema = z.object({
     .refine((value) => !isCommonPassword(value), {
       error: 'よく使用される推測されやすいパスワードは使用できません',
     }),
-  passwordConfirm: z.string().min(1, { error: 'もう一度パスワードを入力してください' }),
+  passwordConfirm: z
+    .string()
+    .trim()
+    .min(1, { error: 'もう一度パスワードを入力してください' }),
   userName: z.coerce
     .string()
     .trim()


### PR DESCRIPTION
[NIST SP 800-63B Revison.4](https://pages.nist.gov/800-63-3/sp800-63b.html) に沿い以下を改善
- 文字種の強制をしない
- 15文字以上のパスワードを要求
- よくある単語を若干禁止
- 15文字以上同じ文字が連続する文字のパスワードは禁止

なお、ASCII 制限のみ継続して行う。
これは現時点では全角文字やスペース込みのパスワードは普及しておらず、ユーザーの混乱を防ぐため。