### PR TITLE
Fix: CORS設定から、Access-Control-Allowを削除し、セキュリティ強化とパスキーの警告解除

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,13 +17,6 @@ const nextConfig = {
   async headers() {
     if (process.env.NODE_ENV === 'development') return [];
 
-    // CORS 設定のため、環境変数から URL を取得（デフォルトはローカルホスト）
-    // NOTE: Access-Control-Allow-Origin は末尾スラッシュ無しの Origin 形式に正規化する
-    const urlValue = (process.env.NEXT_PUBLIC_ORIGIN_URL ?? 'http://localhost:3000').replace(
-      /\/$/,
-      ''
-    );
-
     return [
       {
         source: '/(.*)',
@@ -63,8 +56,6 @@ const nextConfig = {
       {
         source: '/api/:path*',
         headers: [
-          { key: 'Access-Control-Allow-Credentials', value: 'false' },
-          { key: 'Access-Control-Allow-Origin', value: urlValue },
           { key: 'Access-Control-Allow-Methods', value: 'GET,DELETE,POST,PUT,PATCH' },
           {
             key: 'Access-Control-Allow-Headers',
@@ -98,8 +89,6 @@ const nextConfig = {
       {
         source: '/api/auth/:path*',
         headers: [
-          { key: 'Access-Control-Allow-Credentials', value: 'true' },
-          { key: 'Access-Control-Allow-Origin', value: urlValue },
           { key: 'Access-Control-Allow-Methods', value: 'GET,DELETE,POST,PUT,PATCH' },
           {
             key: 'Access-Control-Allow-Headers',
@@ -133,8 +122,6 @@ const nextConfig = {
       {
         source: '/api/admin/:path*',
         headers: [
-          { key: 'Access-Control-Allow-Credentials', value: 'true' },
-          { key: 'Access-Control-Allow-Origin', value: urlValue },
           { key: 'Access-Control-Allow-Methods', value: 'GET,DELETE,POST,PUT,PATCH' },
           {
             key: 'Access-Control-Allow-Headers',


### PR DESCRIPTION
Copilotより、ややセキュリティリスクもあった模様
> Access-Control-Allow-Origin を固定値で指定すると：
> 
> ❌ 外部サイトから patatan.com の API を叩けるようになる
> （ブラウザが patatan.com のレスポンスを許可してしまう）
> 
> これは CSRF の攻撃面を広げる。
> Cookie 認証（passkey も Cookie）なので、外部サイトから API を叩けるようになるのは危険。